### PR TITLE
feat(cascading): cascading commands for easier setup

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,11 +1,6 @@
 {
-  "require": [
-    "test/helpers/init.js",
-    "ts-node/register"
-  ],
-  "watch-extensions": [
-    "ts"
-  ],
+  "require": ["test/helpers/init.js", "ts-node/register"],
+  "watch-extensions": ["ts"],
   "recursive": true,
   "reporter": "spec",
   "timeout": 60000

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -43,12 +43,5 @@ ${color.bold("Client key")} : ${color.green(config.client_key)}
     await updateUserConfig({
       base_url: baseUrl,
     });
-
-    // NOTE: it's not suitable but couldn't find a proper way
-    // to mock `this.config.runCommand` in tests
-    if (process.env.NODE_ENV !== "test") {
-      await this.config.runCommand("login");
-      await this.config.runCommand("project");
-    }
   }
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -2,7 +2,7 @@ import { input } from "@inquirer/prompts";
 import color from "@oclif/color";
 import { Command, Flags } from "@oclif/core";
 
-import { readUserConfig, updateUserConfig } from "../utils/config";
+import { UserConfig, readUserConfig, updateUserConfig } from "../utils/config";
 
 export default class Config extends Command {
   static args = {};
@@ -17,7 +17,7 @@ export default class Config extends Command {
     }),
   };
 
-  public async run(): Promise<void> {
+  public async run(): Promise<UserConfig | undefined> {
     const { flags } = await this.parse(Config);
     const config = await readUserConfig();
 
@@ -40,7 +40,7 @@ ${color.bold("Client key")} : ${color.green(config.client_key)}
       message: "What is URL of your Progressively instance",
     });
 
-    await updateUserConfig({
+    return updateUserConfig({
       base_url: baseUrl,
     });
   }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -44,15 +44,6 @@ ${color.bold("Client key")} : ${color.green(config.client_key)}
       base_url: baseUrl,
     });
 
-    const clientKey = await input({
-      default: config.client_key,
-      message: "Please enter the client key",
-    });
-
-    await updateUserConfig({
-      client_key: clientKey,
-    });
-
     // NOTE: it's not suitable but couldn't find a proper way
     // to mock `this.config.runCommand` in tests
     if (process.env.NODE_ENV !== "test") {

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -42,17 +42,7 @@ export default class Env extends Command {
   }
 
   private async guardConfig(): Promise<UserConfig> {
-    let config = await readUserConfig();
-
-    while (!config.base_url) {
-      // eslint-disable-next-line no-await-in-loop
-      config = await this.config.runCommand("config");
-    }
-
-    while (!config.access_token) {
-      // eslint-disable-next-line no-await-in-loop
-      await this.config.runCommand("login");
-    }
+    const config = await readUserConfig();
 
     if (!config.project_id) {
       await this.config.runCommand("project");

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -1,0 +1,63 @@
+import { select } from "@inquirer/prompts";
+import { Command } from "@oclif/core";
+
+import { UserConfig, readUserConfig, updateUserConfig } from "../utils/config";
+import { getHttpClient } from "../utils/http";
+
+export default class Env extends Command {
+  static args = {};
+
+  static description = "List the environments of the active project";
+
+  static examples = ["<%= config.bin %> <%= command.id %>"];
+
+  public async run(): Promise<void> {
+    const config = await this.guardConfig();
+
+    const httpClient = await getHttpClient(true);
+
+    const { data: envs } = await httpClient.get(
+      `/projects/${config.project_id}/environments`,
+    );
+
+    if (envs.length === 0) {
+      throw new Error(
+        `There are no environments available on this project. Please, make sure to create one in the UI.`,
+      );
+    }
+
+    const clientKey = await select({
+      choices: envs.map((env: any) => ({
+        name: env.name,
+        value: env.clientKey,
+      })),
+      message: "Which env do you want to use?",
+    });
+
+    await updateUserConfig({
+      client_key: String(clientKey),
+    });
+
+    this.log("Client key set up. You can now request your flags");
+  }
+
+  private async guardConfig(): Promise<UserConfig> {
+    let config = await readUserConfig();
+
+    while (!config.base_url) {
+      // eslint-disable-next-line no-await-in-loop
+      config = await this.config.runCommand("config");
+    }
+
+    while (!config.access_token) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.config.runCommand("login");
+    }
+
+    if (!config.project_id) {
+      await this.config.runCommand("project");
+    }
+
+    return config;
+  }
+}

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -11,7 +11,7 @@ export default class Env extends Command {
 
   static examples = ["<%= config.bin %> <%= command.id %>"];
 
-  public async run(): Promise<void> {
+  public async run(): Promise<UserConfig | undefined> {
     const config = await this.guardConfig();
 
     const httpClient = await getHttpClient(true);
@@ -34,18 +34,20 @@ export default class Env extends Command {
       message: "Which env do you want to use?",
     });
 
-    await updateUserConfig({
+    const nextConfig = await updateUserConfig({
       client_key: String(clientKey),
     });
 
     this.log("Client key set up. You can now request your flags");
+
+    return nextConfig;
   }
 
   private async guardConfig(): Promise<UserConfig> {
-    const config = await readUserConfig();
+    let config = await readUserConfig();
 
     if (!config.project_id) {
-      await this.config.runCommand("project");
+      config = await this.config.runCommand("project");
     }
 
     return config;

--- a/src/commands/flag.ts
+++ b/src/commands/flag.ts
@@ -99,10 +99,10 @@ export default class Flag extends Command {
   }
 
   private async guardConfig(): Promise<UserConfig> {
-    const config = await readUserConfig();
+    let config = await readUserConfig();
 
     if (!config.client_key) {
-      await this.config.runCommand("env");
+      config = await this.config.runCommand("env");
     }
 
     return config;

--- a/src/commands/flag.ts
+++ b/src/commands/flag.ts
@@ -1,8 +1,7 @@
 import { confirm, select } from "@inquirer/prompts";
-import { Command, Flags } from "@oclif/core";
-import _ from "lodash";
+import { Command, Flags, ux } from "@oclif/core";
 
-import { readUserConfig } from "../utils/config";
+import { UserConfig, readUserConfig } from "../utils/config";
 import * as flagUtils from "../utils/flag";
 import { getHttpClient } from "../utils/http";
 
@@ -26,7 +25,7 @@ export default class Flag extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(Flag);
 
-    const config = await readUserConfig();
+    const config = await this.guardConfig();
     const httpClient = await getHttpClient(true);
 
     if (flags.create || flags["create-only"]) {
@@ -48,52 +47,64 @@ export default class Flag extends Command {
       httpClient.get(`/projects/${config.project_id}/environments`),
     ]);
 
-    const environmentsById = _.keyBy(environments, "uuid");
+    const currentEnv = environments.find(
+      (env: any) => env.clientKey === config.client_key,
+    );
+
+    this.log(
+      `You are about to modify feature flags status on ${currentEnv.name.toUpperCase()}`,
+    );
+
+    const localFlags = featureFlags.map((featureFlag: any) => {
+      const flagEnv = featureFlag.flagEnvironment.find(
+        (flagEnv: any) => flagEnv.environmentId === currentEnv.uuid,
+      );
+
+      return {
+        name: featureFlag.name,
+        status: flagEnv.status,
+        value: featureFlag.uuid,
+      };
+    });
 
     const selectedFlagId = await select({
-      choices: featureFlags.map((featureFlag: any) => ({
-        description: featureFlag.description,
-        name: featureFlag.name,
-        value: featureFlag.uuid,
+      choices: localFlags.map((localFlag: any) => ({
+        ...localFlag,
+        name: `${localFlag.name} (actual status ${localFlag.status})`,
       })),
       message: "Which feature flag do you want to update",
     });
 
-    const selectedFlag = featureFlags.find(
-      (featureFlag: any) => featureFlag.uuid === selectedFlagId,
+    const selectedFlag = localFlags.find(
+      (featureFlag: any) => featureFlag.value === selectedFlagId,
     );
 
-    for (const flagEnvironment of selectedFlag.flagEnvironment) {
-      const envrionment = environmentsById[flagEnvironment.environmentId];
+    const nextStatus =
+      selectedFlag.status === "ACTIVATED" ? "NOT_ACTIVATED" : "ACTIVATED";
 
-      const switchStatus = {
-        ACTIVATED: "NOT_ACTIVATED",
-        NOT_ACTIVATED: "ACTIVATED",
-      };
+    await confirm({
+      message: `Do you want to update ${selectedFlag.name} on ${currentEnv.name} to ${nextStatus}?`,
+    });
 
-      this.log(
-        `\nThe flag ${selectedFlag.name} is currently ${flagEnvironment.status} in ${envrionment.name}`,
-      );
+    ux.action.start("Switching status...");
+    await httpClient.put(
+      `/environments/${currentEnv.uuid}/flags/${selectedFlagId}`,
+      {
+        status: nextStatus,
+      },
+    );
+    ux.action.stop();
 
-      const switchedStatus =
-        switchStatus[flagEnvironment.status as "ACTIVATED" | "NOT_ACTIVATED"];
+    this.log(`The flag has been successfully`);
+  }
 
-      // eslint-disable-next-line no-await-in-loop
-      await confirm({
-        message: `Do you want to set it to ${switchedStatus}`,
-      });
+  private async guardConfig(): Promise<UserConfig> {
+    const config = await readUserConfig();
 
-      // eslint-disable-next-line no-await-in-loop
-      await httpClient.put(
-        `/environments/${flagEnvironment.environmentId}/flags/${selectedFlagId}`,
-        {
-          status: switchedStatus,
-        },
-      );
-
-      this.log(
-        `The flag ${selectedFlag.name} has been updated to ${switchedStatus} in ${envrionment.name}`,
-      );
+    if (!config.client_key) {
+      await this.config.runCommand("env");
     }
+
+    return config;
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -19,7 +19,12 @@ export default class Login extends Command {
   static flags = {};
 
   public async run(): Promise<void> {
-    const config = await readUserConfig();
+    let config = await readUserConfig();
+
+    while (!config.base_url) {
+      // eslint-disable-next-line no-await-in-loop
+      config = await this.config.runCommand("config");
+    }
 
     const email = await input({
       default: config.email,

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,6 +4,7 @@ import { AxiosError } from "axios";
 
 import { login } from "../utils/auth";
 import {
+  UserConfig,
   getUserConfigPath,
   readUserConfig,
   updateUserConfig,
@@ -19,12 +20,7 @@ export default class Login extends Command {
   static flags = {};
 
   public async run(): Promise<void> {
-    let config = await readUserConfig();
-
-    while (!config.base_url) {
-      // eslint-disable-next-line no-await-in-loop
-      config = await this.config.runCommand("config");
-    }
+    const config = await this.guardConfig();
 
     const email = await input({
       default: config.email,
@@ -88,5 +84,16 @@ export default class Login extends Command {
         }
       }
     }
+  }
+
+  private async guardConfig(): Promise<UserConfig> {
+    let config = await readUserConfig();
+
+    while (!config.base_url) {
+      // eslint-disable-next-line no-await-in-loop
+      config = await this.config.runCommand("config");
+    }
+
+    return config;
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -19,7 +19,7 @@ export default class Login extends Command {
 
   static flags = {};
 
-  public async run(): Promise<void> {
+  public async run(): Promise<UserConfig | undefined> {
     const config = await this.guardConfig();
 
     const email = await input({
@@ -52,7 +52,7 @@ export default class Login extends Command {
 
       ux.action.stop();
 
-      await updateUserConfig({
+      const nextConfig = await updateUserConfig({
         access_token: accessToken,
         refresh_token: refreshToken,
       });
@@ -61,9 +61,7 @@ export default class Login extends Command {
         `Your access token has been stored in the config located at ${getUserConfigPath()}`,
       );
 
-      await this.config.runCommand("project");
-
-      this.log(`Run the environments command to switch`);
+      return nextConfig;
     } catch (error) {
       if (error instanceof AxiosError) {
         switch (error.response?.status) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -64,6 +64,10 @@ export default class Login extends Command {
       this.log(
         `Your access token has been stored in the config located at ${getUserConfigPath()}`,
       );
+
+      await this.config.runCommand("project");
+
+      this.log(`Run the environments command to switch`);
     } catch (error) {
       if (error instanceof AxiosError) {
         switch (error.response?.status) {

--- a/src/commands/me.ts
+++ b/src/commands/me.ts
@@ -1,5 +1,6 @@
 import { Command } from "@oclif/core";
 
+import { UserConfig, readUserConfig } from "../utils/config";
 import { getHttpClient } from "../utils/http";
 
 export default class Me extends Command {
@@ -12,6 +13,7 @@ export default class Me extends Command {
   static flags = {};
 
   public async run(): Promise<void> {
+    await this.guardConfig();
     const httpClient = await getHttpClient(true);
 
     const { data } = await httpClient.get("/users/me");
@@ -22,5 +24,16 @@ Full name : ${data.fullname}
 Email     : ${data.email}
     `.trim(),
     );
+  }
+
+  private async guardConfig(): Promise<UserConfig> {
+    let config = await readUserConfig();
+
+    while (!config.access_token) {
+      // eslint-disable-next-line no-await-in-loop
+      config = await this.config.runCommand("login");
+    }
+
+    return config;
   }
 }

--- a/src/commands/me.ts
+++ b/src/commands/me.ts
@@ -14,6 +14,7 @@ export default class Me extends Command {
 
   public async run(): Promise<void> {
     await this.guardConfig();
+
     const httpClient = await getHttpClient(true);
 
     const { data } = await httpClient.get("/users/me");

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -23,7 +23,7 @@ export default class Project extends Command {
     }),
   };
 
-  public async run(): Promise<void> {
+  public async run(): Promise<UserConfig | undefined> {
     await this.guardConfig();
     const { flags } = await this.parse(Project);
     const httpClient = await getHttpClient(true);
@@ -104,7 +104,7 @@ export default class Project extends Command {
           });
 
     if (projectId) {
-      await updateUserConfig({
+      const config = await updateUserConfig({
         project_id: projectId,
       });
 
@@ -113,15 +113,17 @@ export default class Project extends Command {
       );
 
       this.log(`Current project : ${selectedProject.project.name}`);
+
+      return config;
     }
   }
 
   private async guardConfig(): Promise<UserConfig> {
-    const config = await readUserConfig();
+    let config = await readUserConfig();
 
     while (!config.access_token) {
       // eslint-disable-next-line no-await-in-loop
-      await this.config.runCommand("login");
+      config = await this.config.runCommand("login");
     }
 
     return config;

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -25,7 +25,6 @@ export default class Project extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(Project);
-
     const httpClient = await getHttpClient(true);
 
     const { data: projects } = await httpClient.get("/projects");
@@ -104,7 +103,7 @@ export default class Project extends Command {
           });
 
     if (projectId) {
-      updateUserConfig({
+      await updateUserConfig({
         project_id: projectId,
       });
 

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -2,7 +2,7 @@ import { confirm, input, select } from "@inquirer/prompts";
 import { color } from "@oclif/color";
 import { Command, Flags } from "@oclif/core";
 
-import { updateUserConfig } from "../utils/config";
+import { UserConfig, readUserConfig, updateUserConfig } from "../utils/config";
 import { getHttpClient } from "../utils/http";
 
 export default class Project extends Command {
@@ -24,6 +24,7 @@ export default class Project extends Command {
   };
 
   public async run(): Promise<void> {
+    await this.guardConfig();
     const { flags } = await this.parse(Project);
     const httpClient = await getHttpClient(true);
 
@@ -113,5 +114,16 @@ export default class Project extends Command {
 
       this.log(`Current project : ${selectedProject.project.name}`);
     }
+  }
+
+  private async guardConfig(): Promise<UserConfig> {
+    const config = await readUserConfig();
+
+    while (!config.access_token) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.config.runCommand("login");
+    }
+
+    return config;
   }
 }

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -2,7 +2,7 @@ import { input, password } from "@inquirer/prompts";
 import { Command, ux } from "@oclif/core";
 
 import { login } from "../utils/auth";
-import { updateUserConfig } from "../utils/config";
+import { UserConfig, readUserConfig, updateUserConfig } from "../utils/config";
 import { getHttpClient } from "../utils/http";
 
 export default class Register extends Command {
@@ -15,6 +15,7 @@ export default class Register extends Command {
   static flags = {};
 
   public async run(): Promise<void> {
+    await this.guardConfig();
     const httpClient = await getHttpClient();
 
     const fullname = await input({ message: "What is your fullname" });
@@ -57,5 +58,16 @@ export default class Register extends Command {
         "An error has been detected. Did you already create the admin user?",
       );
     }
+  }
+
+  private async guardConfig(): Promise<UserConfig> {
+    let config = await readUserConfig();
+
+    while (!config.base_url) {
+      // eslint-disable-next-line no-await-in-loop
+      config = await this.config.runCommand("config");
+    }
+
+    return config;
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,1 @@
+export class NoConfig extends Error {}

--- a/src/hooks/init/refresh.ts
+++ b/src/hooks/init/refresh.ts
@@ -18,7 +18,8 @@ const hook: Hook<"init"> = async function (opts) {
       });
     }
   } catch {
-    this.log("We couldn't authenticate you. Please execute the login command");
+    // silent fail for now. The user will be authenticated anyways since the
+    // commands are now cascading up
   }
 };
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -18,7 +18,9 @@ export function getUserConfigPath(): string {
   return USER_CONFIG_FILE_PATH;
 }
 
-export async function updateUserConfig(newConfig: UserConfig): Promise<void> {
+export async function updateUserConfig(
+  newConfig: UserConfig,
+): Promise<UserConfig> {
   let finalConfig = newConfig;
 
   if (await fs.pathExists(USER_CONFIG_FILE_PATH)) {
@@ -28,6 +30,8 @@ export async function updateUserConfig(newConfig: UserConfig): Promise<void> {
   }
 
   await fs.writeJSON(USER_CONFIG_FILE_PATH, finalConfig, { spaces: 2 });
+
+  return finalConfig;
 }
 
 export async function readUserConfig(): Promise<UserConfig> {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -32,7 +32,12 @@ export async function updateUserConfig(newConfig: UserConfig): Promise<void> {
 
 export async function readUserConfig(): Promise<UserConfig> {
   const defaultConfig: UserConfig = {
-    base_url: "https://api.progressively.app",
+    access_token: "",
+    base_url: "",
+    client_key: "",
+    email: "",
+    project_id: "",
+    refresh_token: "",
   };
 
   if (await fs.pathExists(USER_CONFIG_FILE_PATH)) {

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -9,7 +9,7 @@ describe("config", () => {
 
   before(() => {
     configUtilsMock = Sinon.mock(configUtils);
-    configUtilsMock.expects("updateUserConfig").twice();
+    configUtilsMock.expects("updateUserConfig").once();
   });
 
   after(() => {

--- a/test/commands/flag.test.ts
+++ b/test/commands/flag.test.ts
@@ -10,6 +10,7 @@ describe("flag", () => {
   test
     .stub(configUtils, "readUserConfig", () => ({
       base_url: "https://api.progressively.app",
+      client_key: "abcd",
       project_id: MOCK_PROJECT_ID,
     }))
     .stub(

--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -20,6 +20,11 @@ describe("login", () => {
     .stdout()
     .stub(prompts, "input", () => "jean@smaug.fr")
     .stub(prompts, "password", () => "azertyuiop")
+    .stub(configUtils, "readUserConfig", () => ({
+      base_url: "https://api.progressively.app",
+      client_key: "abcd",
+      project_id: "1",
+    }))
     .nock("https://api.progressively.app", (api) => {
       api.post("/auth/login").reply(200, {
         access_token: "MOCK_access_token",

--- a/test/commands/me.test.ts
+++ b/test/commands/me.test.ts
@@ -1,7 +1,13 @@
 import { expect, test } from "@oclif/test";
 
+import * as configUtils from "../../src/utils/config";
+
 describe("me", () => {
   test
+    .stub(configUtils, "readUserConfig", () => ({
+      access_token: "yo",
+      base_url: "https://api.progressively.app",
+    }))
     .nock("https://api.progressively.app", (api) =>
       api
         .get("/users/me")
@@ -10,9 +16,7 @@ describe("me", () => {
     .stdout()
     .command(["me"])
     .it("should display user's informations", (ctx) => {
-      expect(ctx.stdout).to.contain(`
-Full name : Jean Smaug
-Email     : jean@smaug.fr
-`);
+      expect(ctx.stdout).to.contain(`Jean Smaug`);
+      expect(ctx.stdout).to.contain(`jean@smaug.fr`);
     });
 });

--- a/test/commands/project.test.ts
+++ b/test/commands/project.test.ts
@@ -1,6 +1,7 @@
 import * as prompts from "@inquirer/prompts";
 import { expect, test } from "@oclif/test";
-// import * as configUtils from "../../src/utils/config";
+
+import * as configUtils from "../../src/utils/config";
 // import Sinon from "sinon";
 
 // const configUtilsMock = Sinon.mock(configUtils);
@@ -9,6 +10,10 @@ describe("project", () => {
   test
     .stdout()
     .stub(prompts, "confirm", () => false)
+    .stub(configUtils, "readUserConfig", () => ({
+      access_token: "yo",
+      base_url: "https://api.progressively.app",
+    }))
     .nock("https://api.progressively.app", (api) => {
       api.get("/projects").reply(200, []);
     })

--- a/test/commands/register.test.ts
+++ b/test/commands/register.test.ts
@@ -18,6 +18,11 @@ describe("register", () => {
 
   test
     .stdout()
+    .stub(configUtils, "readUserConfig", () => ({
+      base_url: "https://api.progressively.app",
+      client_key: "abcd",
+      project_id: "1",
+    }))
     .stub(
       prompts,
       "input",

--- a/test/commands/types.test.ts
+++ b/test/commands/types.test.ts
@@ -2,6 +2,10 @@ import { expect, test } from "@oclif/test";
 import fsPromises from "node:fs/promises";
 import sinon from "sinon";
 
+import * as configUtils from "../../src/utils/config";
+
+const apiRoot = "https://api.progressively.app";
+
 process.cwd = () => "/mock-current-folder";
 
 describe("types", () => {
@@ -26,9 +30,15 @@ describe("types", () => {
   });
 
   test
-    .nock("https://api.progressively.app", (api) =>
+    .stub(configUtils, "readUserConfig", () => ({
+      access_token: "yo",
+      base_url: apiRoot,
+      client_key: "abcd",
+      project_id: "1",
+    }))
+    .nock(apiRoot, (api) =>
       api
-        .get("/sdk/undefined/types/gen")
+        .get("/sdk/abcd/types/gen")
         .reply(
           200,
           'declare module "@progressively/types" {export interface FlagDict {background: boolean;}export interface FlagDictWithCustomString {background: string | boolean;}}',

--- a/test/hooks/init/refresh.test.ts
+++ b/test/hooks/init/refresh.test.ts
@@ -16,6 +16,12 @@ describe("hooks", () => {
 
   test
     .stdout()
+    .stub(configUtils, "readUserConfig", () => ({
+      access_token: "yo",
+      base_url: "https://api.progressively.app",
+      client_key: "abcd",
+      project_id: "1",
+    }))
     .nock("https://api.progressively.app", (api) => {
       api.get("/auth/refresh").reply(200, {
         access_token: "MOCK_access_token",


### PR DESCRIPTION
Adding guard on config and cascading up. The idea is that if I first run `progressively flag` instead of having a command inviting me to run something else, I run all the previous required command until reaching config.

Basically, flag will check the env, that will check the project, that will check the auth status that will check the config.

It's practical because if one of the intermediate steps is validated, it does not go to the upper layer. So if you are already setup and running `flag`, you only get the flags. If you run `flags` with no auth token, it will go until reaching login.